### PR TITLE
Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,12 @@ matrix:
         # development dependencies
         - php: 7.4
           env: DEPENDENCIES='dev'
+        # development dependencies
+        - php: 8.0
+          env: COMPOSER_FLAGS="--prefer-stable"
     allow_failures:
         # development dependencies
-        - php: 7.4
+        - php: nightly
           env: DEPENDENCIES='dev'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 
 before_install:
     - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex
     - if [ "$DEPENDENCIES" != "" ]; then composer config minimum-stability $DEPENDENCIES; fi
     - if [ "$SYMFONY_LTS" != "" ]; then composer require --dev --no-update symfony/lts=$SYMFONY_LTS; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,15 @@ matrix:
         # Symfony 5.0
         - php: 7.4
           env: SYMFONY_REQUIRE="5.0.*" PHP_CS=yes COMPOSER_FLAGS="--prefer-stable"
-        # Newest dependencies
+        # Newest dependencies php 7.4
         - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable"
-        # development dependencies
-        - php: 7.4
-          env: DEPENDENCIES='dev'
-        # development dependencies
+        # Newest dependnecies php 8.0
         - php: 8.0
           env: COMPOSER_FLAGS="--prefer-stable"
+        # development dependencies
+        - php: nightly
+          env: DEPENDENCIES='dev'
     allow_failures:
         # development dependencies
         - php: nightly

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -23,7 +23,7 @@ class ClassUtils
         $namespace = false;
         $tokens = token_get_all(file_get_contents($file));
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             $namespaceToken = T_NAME_QUALIFIED;
         } else {
             $namespaceToken = T_STRING;
@@ -44,7 +44,7 @@ class ClassUtils
                 do {
                     $namespace .= $token[1];
                     $token = $tokens[++$i];
-                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken]));
+                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken], true));
             }
 
             if (T_CLASS === $token[0]) {

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -22,6 +22,13 @@ class ClassUtils
         $class = false;
         $namespace = false;
         $tokens = token_get_all(file_get_contents($file));
+
+        if (defined('T_NAME_QUALIFIED')) {
+            $namespaceToken = T_NAME_QUALIFIED;
+        } else {
+            $namespaceToken = T_STRING;
+        }
+
         for ($i = 0, $count = \count($tokens); $i < $count; ++$i) {
             $token = $tokens[$i];
 
@@ -33,12 +40,12 @@ class ClassUtils
                 return $namespace . '\\' . $token[1];
             }
 
-            if (true === $namespace && T_STRING === $token[0]) {
+            if (true === $namespace && $namespaceToken === $token[0]) {
                 $namespace = '';
                 do {
                     $namespace .= $token[1];
                     $token = $tokens[++$i];
-                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, T_STRING], true));
+                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken], true));
             }
 
             if (T_CLASS === $token[0]) {

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -23,9 +23,14 @@ class ClassUtils
         $namespace = false;
         $tokens = token_get_all(file_get_contents($file));
 
+
         if (defined('T_NAME_QUALIFIED')) {
             $namespaceToken = T_NAME_QUALIFIED;
         } else {
+            if (!defined('T_NAME_FULLY_QUALIFIED')) {
+                define('T_NAME_FULLY_QUALIFIED', T_STRING);
+                define('T_NAME_QUALIFIED', T_STRING);
+            }
             $namespaceToken = T_STRING;
         }
 
@@ -45,7 +50,7 @@ class ClassUtils
                 do {
                     $namespace .= $token[1];
                     $token = $tokens[++$i];
-                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken]));
+                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED]));
             }
 
             if (T_CLASS === $token[0]) {

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -23,7 +23,6 @@ class ClassUtils
         $namespace = false;
         $tokens = token_get_all(file_get_contents($file));
 
-
         if (PHP_VERSION_ID >= 80000) {
             $namespaceToken = T_NAME_QUALIFIED;
         } else {

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -45,7 +45,7 @@ class ClassUtils
                 do {
                     $namespace .= $token[1];
                     $token = $tokens[++$i];
-                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken], true));
+                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken]));
             }
 
             if (T_CLASS === $token[0]) {

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -24,7 +24,7 @@ class ClassUtils
         $tokens = token_get_all(file_get_contents($file));
 
 
-        if (PHP_VERSION_ID > 70500 && defined('T_NAME_QUALIFIED')) {
+        if (PHP_VERSION_ID >= 80000) {
             $namespaceToken = T_NAME_QUALIFIED;
         } else {
             $namespaceToken = T_STRING;

--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -24,19 +24,14 @@ class ClassUtils
         $tokens = token_get_all(file_get_contents($file));
 
 
-        if (defined('T_NAME_QUALIFIED')) {
+        if (PHP_VERSION_ID > 70500 && defined('T_NAME_QUALIFIED')) {
             $namespaceToken = T_NAME_QUALIFIED;
         } else {
-            if (!defined('T_NAME_FULLY_QUALIFIED')) {
-                define('T_NAME_FULLY_QUALIFIED', T_STRING);
-                define('T_NAME_QUALIFIED', T_STRING);
-            }
             $namespaceToken = T_STRING;
         }
 
         for ($i = 0, $count = \count($tokens); $i < $count; ++$i) {
             $token = $tokens[$i];
-
             if (!\is_array($token)) {
                 continue;
             }
@@ -50,7 +45,7 @@ class ClassUtils
                 do {
                     $namespace .= $token[1];
                     $token = $tokens[++$i];
-                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED]));
+                } while ($i < $count && \is_array($token) && \in_array($token[0], [T_NS_SEPARATOR, $namespaceToken]));
             }
 
             if (T_CLASS === $token[0]) {

--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -261,7 +261,7 @@ EOF;
                 LIBXML_ERR_WARNING === $error->level ? 'WARNING' : 'ERROR',
                 $error->code,
                 trim($error->message),
-                $error->file ? $error->file : 'n/a',
+                $error->file ?: 'n/a',
                 $error->line,
                 $error->column
             );

--- a/Tests/DependencyInjection/RestRoutingExtensionTest.php
+++ b/Tests/DependencyInjection/RestRoutingExtensionTest.php
@@ -47,7 +47,7 @@ class RestRoutingExtensionTest extends TestCase
      */
     private $defaultFormat;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->container->setParameter('kernel.bundles', ['JMSSerializerBundle' => true]);
@@ -57,7 +57,7 @@ class RestRoutingExtensionTest extends TestCase
         $this->formats = ['json' => true, 'xml' => true];
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->container, $this->extension);
     }

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -41,7 +41,7 @@ class RestRouteLoaderTest extends LoaderTest
             $this->assertNotNull($route, sprintf('route for %s does not exist', $name));
             $this->assertSame($params['path'], $route->getPath(), 'Path does not match for route: ' . $name);
             $this->assertSame($params['methods'][0], $methods[0], 'Method does not match for route: ' . $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'Controller does not match for route: ' . $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), 'Controller does not match for route: ' . $name);
         }
     }
 
@@ -63,7 +63,7 @@ class RestRouteLoaderTest extends LoaderTest
             $this->assertNotNull($route, sprintf('route for %s does not exist', $name));
             $this->assertSame($params['path'], $route->getPath(), 'Path does not match for route: ' . $name);
             $this->assertSame($params['methods'][0], $methods[0], 'Method does not match for route: ' . $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'Controller does not match for route: ' . $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), 'Controller does not match for route: ' . $name);
         }
     }
 
@@ -111,7 +111,7 @@ class RestRouteLoaderTest extends LoaderTest
             unset($requirements['_method']);
             $this->assertSame($params['requirements'], $requirements, 'requirements failed to match for ' . $name);
 
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
             if (isset($params['condition'])) {
                 $this->assertSame($params['condition'], $route->getCondition(), 'condition failed to match for ' . $name);
             }
@@ -159,7 +159,7 @@ class RestRouteLoaderTest extends LoaderTest
             unset($requirements['_method']);
             $this->assertSame($params['requirements'], $requirements, 'requirements failed to match for ' . $name);
 
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
             if (isset($params['condition'])) {
                 $this->assertSame($params['condition'], $route->getCondition(), 'condition failed to match for ' . $name);
             }
@@ -188,7 +188,7 @@ class RestRouteLoaderTest extends LoaderTest
             unset($requirements['_method']);
             $this->assertSame($params['requirements'], $requirements, 'requirements failed to match for ' . $name);
 
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
             if (isset($params['condition'])) {
                 $this->assertSame($params['condition'], $route->getCondition(), 'condition failed to match for ' . $name);
             }
@@ -217,7 +217,7 @@ class RestRouteLoaderTest extends LoaderTest
             unset($requirements['_method']);
             $this->assertSame($params['requirements'], $requirements, 'requirements failed to match for ' . $name);
 
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), 'controller failed to match for ' . $name);
             if (isset($params['condition']) && true) {
                 $this->assertSame($params['condition'], $route->getCondition(), 'condition failed to match for ' . $name);
             }

--- a/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
@@ -27,23 +27,23 @@ class RestXmlCollectionLoaderTest extends LoaderTest
 {
     /**
      * Test that route route not found.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot find parent resource with name
      */
     public function testLoadThrowsExceptionWithInvalidRouteParent()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot find parent resource with name');
+
         $this->loadFromXmlCollectionFixture('invalid_route_parent.xml');
     }
 
     /**
      * Test that invalid tag.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /This element is not expected. Expected is one of/
      */
     public function testLoadThrowsExceptionWithInvalidTag()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/This element is not expected. Expected is one of/');
+
         $this->loadFromXmlCollectionFixture('invalid_tag.xml');
     }
 
@@ -62,7 +62,7 @@ class RestXmlCollectionLoaderTest extends LoaderTest
             $this->assertNotNull($route, $name);
             $this->assertSame($params['path'], $route->getPath(), $name);
             $this->assertSame($params['methods'][0], $methods[0], $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), $name);
         }
     }
 
@@ -81,7 +81,7 @@ class RestXmlCollectionLoaderTest extends LoaderTest
             $this->assertNotNull($route, $name);
             $this->assertSame($params['path'], $route->getPath(), $name);
             $this->assertSame($params['methods'][0], $methods[0], $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), $name);
         }
     }
 

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -38,34 +38,34 @@ class RestYamlCollectionLoaderTest extends LoaderTest
 
     /**
      * Test that invalid YAML format.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The file "*.+bad_format\.yml" does not contain valid YAML\./
      */
     public function testLoadThrowsExceptionWithInvalidYaml()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/The file "*.+bad_format\.yml" does not contain valid YAML\./');
+
         $this->loadFromYamlCollectionFixture('bad_format.yml');
     }
 
     /**
      * Test that YAML value not an array.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The file "*.+nonvalid.yml" must contain a Yaml mapping \(an array\)\./
      */
     public function testLoadThrowsExceptionWithValueNotArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/The file "*.+nonvalid.yml" must contain a Yaml mapping \(an array\)\./');
+
         $this->loadFromYamlCollectionFixture('nonvalid.yml');
     }
 
     /**
      * Test that route parent not found.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot find parent resource with name
      */
     public function testLoadThrowsExceptionWithInvalidRouteParent()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot find parent resource with name');
+
         $this->loadFromYamlCollectionFixture('invalid_route_parent.yml');
     }
 
@@ -84,7 +84,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
             $this->assertNotNull($route, $name);
             $this->assertSame($params['path'], $route->getPath(), $name);
             $this->assertSame($params['methods'][0], $methods[0], $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), $name);
         }
     }
 
@@ -103,7 +103,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
             $this->assertNotNull($route, $name);
             $this->assertSame($params['path'], $route->getPath(), $name);
             $this->assertSame($params['methods'][0], $methods[0], $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), $name);
         }
     }
 
@@ -122,7 +122,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
             $this->assertNotNull($route, $name);
             $this->assertSame($params['path'], $route->getPath(), $name);
             $this->assertSame($params['methods'][0], $methods[0], $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), $name);
         }
     }
 
@@ -237,7 +237,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
             $this->assertNotNull($route, $name);
             $this->assertSame($params['path'], $route->getPath(), $name);
             $this->assertSame($params['method'], $methods[0], $name);
-            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+            $this->assertStringContainsString($params['controller'], $route->getDefault('_controller'), $name);
         }
 
         $name = 'api_get_billing_payments';

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         ]
     },
     "require": {
-        "php": "^7.2",
+        "php": ">7.2",
         "doctrine/inflector": "^1.4|^2.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         ]
     },
     "require": {
-        "php": ">7.2",
+        "php": "^7.2 || ^8.0",
         "doctrine/inflector": "^1.4|^2.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
@@ -35,7 +35,7 @@
         "friendsofsymfony/rest-bundle": "^2.8 || ^3.0",
         "sensio/framework-extra-bundle": "^5.2.3",
         "symfony/http-foundation": "^4.4|^5.0",
-        "symfony/phpunit-bridge": "^4.1.8|^5.0",
+        "symfony/phpunit-bridge": "^5.2",
         "symfony/validator": "^4.4|^5.0",
         "symfony/serializer": "^4.4|^5.0",
         "symfony/yaml": "^4.4|^5.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
         <ini name="error_reporting" value="-1" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
This PR adds very basic PHP 8 support.

All credits go to @GuilhemN who added that code to [FOSRestBundle](https://github.com/FriendsOfSymfony/FOSRestBundle) in the last release, see here: https://github.com/FriendsOfSymfony/FOSRestBundle/compare/2.8.3...2.8.4 (or the [original rfc](https://wiki.php.net/rfc/namespaced_names_as_token))

I changed the check for `if (defined('T_NAME_QUALIFIED')) {` with a check for the PHP Version, becuase this is more failsafe.
There are at least 2 projects outside, which do define this constant in user land code, see [here]() and [here]().

Open: 
- Squash commits
- Travis