### PR TITLE
Add support for attributes

### DIFF
--- a/Controller/Annotations/NamePrefix.php
+++ b/Controller/Annotations/NamePrefix.php
@@ -21,6 +21,7 @@ use FOS\RestBundle\Controller\Annotations\NamePrefix as OldNamePrefix;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS)]
 class NamePrefix extends Annotation
 {
 }

--- a/Controller/Annotations/NoRoute.php
+++ b/Controller/Annotations/NoRoute.php
@@ -13,7 +13,28 @@
 namespace HandcraftedInTheAlps\RestRoutingBundle\Controller\Annotations;
 
 use FOS\RestBundle\Controller\Annotations\NoRoute as OldNoRoute;
-use Symfony\Component\Routing\Annotation\Route as BaseRoute;
+use Symfony\Component\Routing\Annotation\Route as BaseAnnotationRoute;
+use Symfony\Component\Routing\Attribute\Route as BaseAttributeRoute;
+
+if (class_exists(BaseAttributeRoute::class)) {
+    /**
+     * Compatibility layer for Symfony 6.4 and later.
+     *
+     * @internal
+     */
+    class CompatRoute extends BaseAttributeRoute
+    {
+    }
+} else {
+    /**
+     * Compatibility layer for Symfony 6.3 and earlier.
+     *
+     * @internal
+     */
+    class CompatRoute extends BaseAnnotationRoute
+    {
+    }
+}
 
 /**
  * No Route annotation class.
@@ -21,11 +42,87 @@ use Symfony\Component\Routing\Annotation\Route as BaseRoute;
  * @Annotation
  * @Target({"METHOD","CLASS"})
  */
-class NoRoute extends BaseRoute
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class NoRoute extends CompatRoute
 {
-    public function __construct(array $data)
-    {
-        parent::__construct($data);
+    /**
+     * @param array|string              $data
+     * @param array|string|null         $path
+     * @param array<string|\Stringable> $requirements
+     * @param string[]|string           $methods
+     * @param string[]|string           $schemes
+     *
+     * @throws \TypeError if the $data argument is an unsupported type
+     */
+    public function __construct(
+        $data = [],
+        $path = null,
+        string $name = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        string $host = null,
+        $methods = [],
+        $schemes = [],
+        string $condition = null,
+        int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        string $env = null
+    ) {
+        // Use Reflection to get the constructor from the parent class two levels up (accounting for our compat definition)
+        $method = (new \ReflectionClass($this))->getParentClass()->getParentClass()->getMethod('__construct');
+
+        // The $data constructor parameter was removed in Symfony 6.0 in favor of named arguments
+        if ('data' === $method->getParameters()[0]->getName()) {
+            parent::__construct(
+                $data,
+                $path,
+                $name,
+                $requirements,
+                $options,
+                $defaults,
+                $host,
+                $methods,
+                $schemes,
+                $condition,
+                $priority,
+                $locale,
+                $format,
+                $utf8,
+                $stateless,
+                $env
+            );
+        } else {
+            if (\is_string($data)) {
+                $data = ['path' => $data];
+            } elseif (!\is_array($data)) {
+                throw new \TypeError(sprintf('"%s": Argument $data is expected to be a string or array, got "%s".', __METHOD__, get_debug_type($data)));
+            } elseif (0 !== \count($data) && [] === array_intersect(array_keys($data), ['path', 'name', 'requirements', 'options', 'defaults', 'host', 'methods', 'schemes', 'condition', 'priority', 'locale', 'format', 'utf8', 'stateless', 'env'])) {
+                $localizedPaths = $data;
+                $data = ['path' => $localizedPaths];
+            }
+
+            parent::__construct(
+                $data['path'] ?? $path,
+                $data['name'] ?? $name,
+                $data['requirements'] ?? $requirements,
+                $data['options'] ?? $options,
+                $data['defaults'] ?? $defaults,
+                $data['host'] ?? $host,
+                $data['methods'] ?? $methods,
+                $data['schemes'] ?? $schemes,
+                $data['condition'] ?? $condition,
+                $data['priority'] ?? $priority,
+                $data['locale'] ?? $locale,
+                $data['format'] ?? $format,
+                $data['utf8'] ?? $utf8,
+                $data['stateless'] ?? $stateless,
+                $data['env'] ?? $env
+            );
+        }
 
         if (!$this->getMethods()) {
             $this->setMethods((array) $this->getMethod());

--- a/Controller/Annotations/Prefix.php
+++ b/Controller/Annotations/Prefix.php
@@ -21,6 +21,7 @@ use FOS\RestBundle\Controller\Annotations\Prefix as OldPrefix;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS)]
 class Prefix extends Annotation
 {
 }

--- a/Controller/Annotations/RouteResource.php
+++ b/Controller/Annotations/RouteResource.php
@@ -20,6 +20,7 @@ use FOS\RestBundle\Controller\Annotations\RouteResource as OldRouteResource;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS)]
 class RouteResource
 {
     /**

--- a/Controller/Annotations/Version.php
+++ b/Controller/Annotations/Version.php
@@ -21,6 +21,7 @@ use FOS\RestBundle\Controller\Annotations\Version as OldVersion;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS)]
 class Version extends Annotation
 {
 }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -668,10 +668,10 @@ class RestActionReader
 
         if (\PHP_VERSION_ID > 80000) {
             /** @var \ReflectionAttribute[] $reflectionAttributes */
-            $reflectionAttributes = [
-                ...(class_exists($annotationClass) ? $reflectionMethod->getAttributes($annotationClass, \ReflectionAttribute::IS_INSTANCEOF) : []),
-                ...(class_exists($oldAnnotationClass) ? $reflectionMethod->getAttributes($oldAnnotationClass, \ReflectionAttribute::IS_INSTANCEOF) : []),
-            ];
+            $reflectionAttributes = array_merge(
+                class_exists($annotationClass) ? $reflectionMethod->getAttributes($annotationClass, \ReflectionAttribute::IS_INSTANCEOF) : [],
+                class_exists($oldAnnotationClass) ? $reflectionMethod->getAttributes($oldAnnotationClass, \ReflectionAttribute::IS_INSTANCEOF) : []
+            );
 
             foreach ($reflectionAttributes as $reflectionAttribute) {
                 $annotations[] = $reflectionAttribute->newInstance();

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -447,7 +447,7 @@ class RestActionReader
                         $attribute instanceof ParamConverter &&
                         'fos_rest.request_body' === $attribute->getConverter()
                             ? $attribute->getName() : null;
-                }, $method->getAttributes(ParamConverter::class)) : [],
+                }, $method->getAttributes(ParamConverter::class)) : []
             );
         }
 

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -64,7 +64,7 @@ class RestControllerReader
             return $attributes[0]->newInstance();
         }
 
-        return $this->annotationReader->getClassAnnotation($reflectionClass, Prefix::class);
+        return $this->annotationReader->getClassAnnotation($reflectionClass, $annotationName);
     }
 
     public function read(\ReflectionClass $reflectionClass): RestRouteCollection


### PR DESCRIPTION
The library currently only works with annotations using the reader to read the doc blocks. It completely ignores any attributes and starts doing it's own thing.

I'm unsure about the updates to the attributes/annoations provided by this library. The changes look like they should work but I don't use them. The updates in `NoRoute` were copied from FosRest. 
