### PR TITLE
Added explicit phpdoc for return type of bundle's build method

### DIFF
--- a/RestRoutingBundle.php
+++ b/RestRoutingBundle.php
@@ -23,6 +23,8 @@ class RestRoutingBundle extends Bundle
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function build(ContainerBuilder $container)
     {


### PR DESCRIPTION
This is needed to prevent the following deprecation message in a backwards compatible way: 

> Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "HandcraftedInTheAlps\RestRoutingBundle\RestRoutingBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in vendor/symfony/error-handler/DebugClassLoader.php on line 341

Question: What is the preferred way to add a native return type?