### PR TITLE
Add command to dump all routes as yaml to opt out of this bundle

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -83,7 +83,7 @@ jobs:
 
         steps:
             - name: Checkout project
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
@@ -96,7 +96,7 @@ jobs:
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               id: composer-cache
               with:
                   path: ${{ steps.composer-cache-dir.outputs.dir }}
@@ -131,7 +131,7 @@ jobs:
 
         steps:
             - name: Checkout project
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
@@ -144,7 +144,7 @@ jobs:
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               id: composer-cache
               with:
                   path: ${{ steps.composer-cache-dir.outputs.dir }}

--- a/Command/DumpRoutes.php
+++ b/Command/DumpRoutes.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Yaml\Yaml;
 

--- a/Command/DumpRoutes.php
+++ b/Command/DumpRoutes.php
@@ -85,11 +85,11 @@ class DumpRoutes extends Command
     private function filterMatches(string $name, array $data, ?string $namePrefix, ?string $controllerName): bool
     {
         if (null !== $namePrefix) {
-            return str_starts_with($name, $namePrefix);
+            return 0 === strpos($name, $namePrefix);
         }
 
         if (null !== $controllerName) {
-            return str_starts_with($data['controller'], $controllerName);
+            return 0 === strpos($data['controller'], $controllerName);
         }
 
         return true;

--- a/Command/DumpRoutes.php
+++ b/Command/DumpRoutes.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class GenerateRoutes extends Command
+class DumpRoutes extends Command
 {
     private RouterInterface $router;
 

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -34,6 +34,8 @@ class GenerateRoutes extends Command
             unset($routeData['options']['utf8']);
             $routeData['controller'] = $routeData['defaults']['_controller'] ?? '';
             unset($routeData['defaults']['_controller']);
+            $routeData['format'] = $routeData['defaults']['_format'] ?? '';
+            unset($routeData['defaults']['_controller']);
 
             foreach ($routeData as $key => $value) {
                 if (!$value) {

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace HandcraftedInTheAlps\RestRoutingBundle\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -20,7 +20,7 @@ class GenerateRoutes extends Command
     {
         $this->router = $router;
 
-        parent::__construct('fos-routing:generate-symfony');
+        parent::__construct('fos:rest:routing:dump-symfony-routes');
     }
 
     protected function configure(): void

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -73,7 +73,7 @@ class GenerateRoutes extends Command
                 }
             }
 
-            if ($this->filterMatches($name, $routeData, $namePrefix)) {
+            if ($this->filterMatches($name, $routeData, $namePrefix, $controllerName)) {
                 $routes[$name] = $routeData;
             }
         }

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -60,11 +60,9 @@ class GenerateRoutes extends Command
 
 
         $targetPath = $this->projectDirectory . '/fos-routing.yaml';
-        file_put_contents($targetPath, Yaml::dump($routes));
+        echo Yaml::dump($routes);
 
         $io = new SymfonyStyle($input, $output);
-        $io->note('Generated routes to: ' . $targetPath);
-        $io->comment('This is a list of all routes in the project. Please copy and paste the relevant routes to your config.');
 
         $io->info('If you do not like yaml. You can use the symplify/config-transformer package to change it into php.');
 

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -37,6 +37,7 @@ class GenerateRoutes extends Command
             InputOption::VALUE_REQUIRED,
             'Name of the controller to dump',
         );
+        $this->setDescription('This is a list of all routes in the project. Please copy and paste the relevant routes to your config.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -6,6 +6,7 @@ namespace HandcraftedInTheAlps\RestRoutingBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\RouterInterface;
@@ -24,8 +25,27 @@ class GenerateRoutes extends Command
         parent::__construct('fos-routing:generate-symfony');
     }
 
+    protected function configure(): void
+    {
+        $this->addOption(
+            'name-prefix',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Only show routes whose name is starting with this string',
+        );
+        $this->addOption(
+            'controller-name',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Name of the controller to dump',
+        );
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $namePrefix = $input->getOption('name-prefix');
+        $controllerName = $input->getOption('controller-name');
+
         $routes = [];
         foreach ($this->router->getRouteCollection() as $name => $route) {
             $routeData = $route->__serialize();
@@ -55,16 +75,32 @@ class GenerateRoutes extends Command
                     unset($routeData[$key]);
                 }
             }
-            $routes[$name] = $routeData;
+
+            if ($this->filterMatches($name, $routeData, $namePrefix)) {
+                $routes[$name] = $routeData;
+            }
         }
 
         $targetPath = $this->projectDirectory . '/fos-routing.yaml';
-        $output->writleln(Yaml::dump($routes));
+        $output->writeln(Yaml::dump($routes));
 
         $io = new SymfonyStyle($input, $output);
 
         $io->info('If you do not like yaml. You can use the symplify/config-transformer package to change it into php.');
 
         return Command::SUCCESS;
+    }
+
+    private function filterMatches(string $name, array $data, ?string $namePrefix, ?string $controllerName): bool
+    {
+        if ($namePrefix !== null) {
+            return str_starts_with($name, $namePrefix);
+        }
+
+        if ($controllerName !== null) {
+            return $data['controller'] !== $controllerName;
+        }
+
+        return true;
     }
 }

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -14,12 +14,10 @@ use Symfony\Component\Yaml\Yaml;
 
 class GenerateRoutes extends Command
 {
-    private string $projectDirectory;
     private RouterInterface $router;
 
     public function __construct(string $projectDirectory, RouterInterface $router)
     {
-        $this->projectDirectory = $projectDirectory;
         $this->router = $router;
 
         parent::__construct('fos-routing:generate-symfony');
@@ -81,7 +79,6 @@ class GenerateRoutes extends Command
             }
         }
 
-        $targetPath = $this->projectDirectory . '/fos-routing.yaml';
         $output->writeln(Yaml::dump($routes));
 
         $io = new SymfonyStyle($input, $output);

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HandcraftedInTheAlps\RestRoutingBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class GenerateRoutes extends Command
+{
+    private string $projectDirectory;
+    private RouterInterface $router;
+
+    public function __construct(string $projectDirectory, RouterInterface $router)
+    {
+        $this->projectDirectory = $projectDirectory;
+        $this->router = $router;
+
+        parent::__construct('fos-routing:generate-symfony');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $routes = [];
+        foreach ($this->router->getRouteCollection() as $name => $route) {
+            $routeData = $route->__serialize();
+            // Unset things that are probably defaulted by Symfony
+            unset($routeData['options']['compiler_class']);
+            unset($routeData['options']['utf8']);
+            $routeData['controller'] = $routeData['defaults']['_controller'] ?? '';
+            unset($routeData['defaults']['_controller']);
+
+            foreach ($routeData as $key => $value) {
+                if (!$value) {
+                    unset($routeData[$key]);
+                }
+            }
+            $routes[$name] = $routeData;
+        }
+
+        ksort($routes);
+
+        $targetPath = $this->projectDirectory . '/fos-routing.yaml';
+        file_put_contents($targetPath, Yaml::dump($routes));
+
+        $io = new SymfonyStyle($input, $output);
+        $io->note('Generated routes to: ' . $targetPath);
+        $io->comment('This is a list of all routes in the project. Please copy and paste the relevant routes to your config.');
+
+        $io->info('If you do not like yaml. You can use the symplify/config-transformer package to change it into php.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -59,7 +59,7 @@ class GenerateRoutes extends Command
         }
 
         $targetPath = $this->projectDirectory . '/fos-routing.yaml';
-        echo Yaml::dump($routes);
+        $output->writleln(Yaml::dump($routes));
 
         $io = new SymfonyStyle($input, $output);
 

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -32,6 +32,9 @@ class GenerateRoutes extends Command
             // Unset things that are probably defaulted by Symfony
             unset($routeData['options']['compiler_class']);
             unset($routeData['options']['utf8']);
+            if (\is_array($routeData['methods'] ?? null) && \count($routeData['methods']) === 1) {
+                 $routeData['methods'] = $routeData['methods'][0];
+            }
             $routeData['controller'] = $routeData['defaults']['_controller'] ?? '';
             unset($routeData['defaults']['_controller']);
             $routeData['format'] = $routeData['defaults']['_format'] ?? '';

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -14,7 +14,7 @@ class GenerateRoutes extends Command
 {
     private RouterInterface $router;
 
-    public function __construct(string $projectDirectory, RouterInterface $router)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
 

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -80,10 +80,6 @@ class GenerateRoutes extends Command
 
         $output->writeln(Yaml::dump($routes));
 
-        $io = new SymfonyStyle($input, $output);
-
-        $io->info('If you do not like yaml. You can use the symplify/config-transformer package to change it into php.');
-
         return Command::SUCCESS;
     }
 

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -32,22 +32,22 @@ class GenerateRoutes extends Command
             // Unset things that are probably defaulted by Symfony
             unset($routeData['options']['compiler_class']);
             unset($routeData['options']['utf8']);
-            if (\is_array($routeData['methods'] ?? null) && \count($routeData['methods']) === 1) {
-                 $routeData['methods'] = $routeData['methods'][0];
+            if (\is_array($routeData['methods'] ?? null) && 1 === \count($routeData['methods'])) {
+                $routeData['methods'] = $routeData['methods'][0];
             }
             $routeData['controller'] = $routeData['defaults']['_controller'] ?? '';
             unset($routeData['defaults']['_controller']);
             $routeData['format'] = $routeData['defaults']['_format'] ?? '';
             unset($routeData['defaults']['_controller']);
-            $defaults= $routeData['defaults'] ?? [];
-            $requirements= $routeData['requirements'] ?? [];
+            $defaults = $routeData['defaults'] ?? [];
+            $requirements = $routeData['requirements'] ?? [];
             unset($routeData['defaults']);
             unset($routeData['requirements']);
-            if ($defaults !== []) {
-                 $routeData['defaults'] = $defaults;
+            if ([] !== $defaults) {
+                $routeData['defaults'] = $defaults;
             }
-            if ($requirements !== []) {
-                 $routeData['requirements'] = $requirements;
+            if ([] !== $requirements) {
+                $routeData['requirements'] = $requirements;
             }
 
             foreach ($routeData as $key => $value) {
@@ -57,7 +57,6 @@ class GenerateRoutes extends Command
             }
             $routes[$name] = $routeData;
         }
-
 
         $targetPath = $this->projectDirectory . '/fos-routing.yaml';
         echo Yaml::dump($routes);

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -58,7 +58,6 @@ class GenerateRoutes extends Command
             $routes[$name] = $routeData;
         }
 
-        ksort($routes);
 
         $targetPath = $this->projectDirectory . '/fos-routing.yaml';
         file_put_contents($targetPath, Yaml::dump($routes));

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -36,6 +36,16 @@ class GenerateRoutes extends Command
             unset($routeData['defaults']['_controller']);
             $routeData['format'] = $routeData['defaults']['_format'] ?? '';
             unset($routeData['defaults']['_controller']);
+            $defaults= $routeData['defaults'] ?? [];
+            $requirements= $routeData['requirements'] ?? [];
+            unset($routeData['defaults']);
+            unset($routeData['requirements']);
+            if ($defaults !== []) {
+                 $routeData['defaults'] = $defaults;
+            }
+            if ($requirements !== []) {
+                 $routeData['requirements'] = $requirements;
+            }
 
             foreach ($routeData as $key => $value) {
                 if (!$value) {

--- a/Command/GenerateRoutes.php
+++ b/Command/GenerateRoutes.php
@@ -91,12 +91,12 @@ class GenerateRoutes extends Command
 
     private function filterMatches(string $name, array $data, ?string $namePrefix, ?string $controllerName): bool
     {
-        if ($namePrefix !== null) {
+        if (null !== $namePrefix) {
             return str_starts_with($name, $namePrefix);
         }
 
-        if ($controllerName !== null) {
-            return $data['controller'] !== $controllerName;
+        if (null !== $controllerName) {
+            return str_starts_with($data['controller'], $controllerName);
         }
 
         return true;

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ This bundle provides the automatic route generation for the FOSRestBundle 3.0.
 
 All the installation instructions are located in the [documentation](Resources/doc/1-setting_up_the_bundle.rst).
 
+
+## Opt-out of the `type: rest` routing
+
+You might want to migrate away from this bundle and use normal Symfony routes.
+Via the command inside this bundle you can convert all `type: rest` routes to normal Symfony routes:
+
+```bash
+bin/console fos:rest:routing:dump-symfony-routes
+
+# filter by a specific controller
+bin/console fos:rest:routing:dump-symfony-routes --controller="your.controller.service"
+
+# filter by a specific name prefix
+bin/console fos:rest:routing:dump-symfony-routes --name-prefix="your_prefix."
+```
+
+Copy the result into a `routing.yaml` file of your choice.
+
 ## Switching from FOSRestBundle
 
 If you did before using the FOSRestBundle which removed the auto route generation the switch is easy.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This bundle provides the automatic route generation for the FOSRestBundle 3.0.
 
 All the installation instructions are located in the [documentation](Resources/doc/1-setting_up_the_bundle.rst).
 
-
 ## Opt-out of the `type: rest` routing
 
 You might want to migrate away from this bundle and use normal Symfony routes.

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -54,7 +54,7 @@
 
         <service id="handcraftedinthealps_rest_routing.inflector.doctrine" class="HandcraftedInTheAlps\RestRoutingBundle\Inflector\DoctrineInflector" public="false" />
 
-        <service id="handcraftedinthealps_rest_routing.command" class="HandcraftedInTheAlps\RestRoutingBundle\Command\GenerateRoutes">
+        <service id="handcraftedinthealps_rest_routing.command" class="HandcraftedInTheAlps\RestRoutingBundle\Command\DumpRoutes">
             <argument type="service" id="router" />
             <tag name="console.command" />
          </service>

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -55,7 +55,6 @@
         <service id="handcraftedinthealps_rest_routing.inflector.doctrine" class="HandcraftedInTheAlps\RestRoutingBundle\Inflector\DoctrineInflector" public="false" />
 
         <service id="handcraftedinthealps_rest_routing.command" class="HandcraftedInTheAlps\RestRoutingBundle\Command\GenerateRoutes">
-            <argument>%kernel.project_dir%</argument>
             <argument type="service" id="router" />
             <tag name="console.command" />
          </service>

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -53,6 +53,12 @@
         </service>
 
         <service id="handcraftedinthealps_rest_routing.inflector.doctrine" class="HandcraftedInTheAlps\RestRoutingBundle\Inflector\DoctrineInflector" public="false" />
+
+        <service id="handcraftedinthealps_rest_routing.command" class="HandcraftedInTheAlps\RestRoutingBundle\Command\GenerateRoutes">
+            <argument>%kernel.project_dir%</argument>
+            <argument type="service" id="router" />
+            <tag name="console.command" />
+         </service>
     </services>
 
 </container>

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "php": "^7.2 || ^8.0",
         "doctrine/annotations": "^1.0|^2.0",
         "doctrine/inflector": "^1.4.1|^2.0",
+        "symfony/console": "^4.4|^5.0|^6.0|^7.0",
         "symfony/config": "^4.4|^5.0|^6.0|^7.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0|^7.0",
         "symfony/finder": "^4.4|^5.0|^6.0|^7.0",


### PR DESCRIPTION
We want to remove this plugin from the sulu core code. For that we need a way to generate the routes as a yaml file and copy it over to the project.

This PR adds a command that dumps **all** routes as YAML then you can copy over what you need.
If you want XML routing just use the Symfony router: `bin/console debug:router --format xml`
If you want php routing. Dump the yaml and convert it with the `symplify/config-transformer` package.